### PR TITLE
Removed checkout repo from generate-update

### DIFF
--- a/.github/workflows/automate.yml
+++ b/.github/workflows/automate.yml
@@ -75,6 +75,5 @@ jobs:
         run: |
           /usr/bin/git config --local user.email "action@github.com"
           /usr/bin/git config --local user.name "GitHub Action"
-          echo "Current directory: $(pwd)"
           /usr/bin/git add datasets.py
           /usr/bin/git diff --staged --quiet || /usr/bin/git commit -m "Update datasets [github action]"

--- a/.github/workflows/generate-update.yml
+++ b/.github/workflows/generate-update.yml
@@ -16,14 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       #----------------------------------------------
-      #       check out repo
-      #----------------------------------------------
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          ssh-key:
-            ${{secrets.DEPLOY_ACTION_SECRET}}
-      #----------------------------------------------
       #       set up python
       #----------------------------------------------
       - name: Set up python

--- a/censusdis/datasets.py
+++ b/censusdis/datasets.py
@@ -11,6 +11,7 @@ But you can always use raw strings. For example, even for `ACS5` you can use
 
 `acs/acs5` instead.
 """
+
 ABS_CB = "abscb"
 
 ABS_CBO = "abscbo"

--- a/censusdis/datasets.py
+++ b/censusdis/datasets.py
@@ -11,8 +11,6 @@ But you can always use raw strings. For example, even for `ACS5` you can use
 
 `acs/acs5` instead.
 """
-
-
 ABS_CB = "abscb"
 
 ABS_CBO = "abscbo"


### PR DESCRIPTION
Because it might be causing the commit to not be pushed and we don't need to neccessarily interact with the repo contents to push.